### PR TITLE
Add email list view

### DIFF
--- a/web-app/api/api.py
+++ b/web-app/api/api.py
@@ -1,8 +1,41 @@
 import time
-from flask import Flask
+from flask import Flask, jsonify
 
 app = Flask(__name__)
 
 @app.route('/api/time')
 def get_current_time():
     return {'time': time.time()}
+
+
+@app.route('/api/emails')
+def get_emails():
+    """Return a list of fake email data."""
+    now = time.time()
+    emails = [
+        {
+            "id": 1,
+            "from": "alice@example.com",
+            "subject": "Welcome to dMail!",
+            "timestamp": now - 3600,
+        },
+        {
+            "id": 2,
+            "from": "bob@example.com",
+            "subject": "Meeting schedule",
+            "timestamp": now - 7200,
+        },
+        {
+            "id": 3,
+            "from": "carol@example.com",
+            "subject": "Re: Vacation plans",
+            "timestamp": now - 86400,
+        },
+        {
+            "id": 4,
+            "from": "dan@example.com",
+            "subject": "Newsletter - July",
+            "timestamp": now - 172800,
+        },
+    ]
+    return jsonify(emails)

--- a/web-app/src/App.css
+++ b/web-app/src/App.css
@@ -1,42 +1,47 @@
-#root {
-  max-width: 1280px;
+.app {
+  max-width: 800px;
   margin: 0 auto;
-  padding: 2rem;
-  text-align: center;
+  padding: 1rem;
+  color: inherit;
 }
 
-.logo {
-  height: 6em;
-  padding: 1.5em;
-  will-change: filter;
-  transition: filter 300ms;
-}
-.logo:hover {
-  filter: drop-shadow(0 0 2em #646cffaa);
-}
-.logo.react:hover {
-  filter: drop-shadow(0 0 2em #61dafbaa);
+.header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1rem;
 }
 
-@keyframes logo-spin {
-  from {
-    transform: rotate(0deg);
-  }
-  to {
-    transform: rotate(360deg);
-  }
+.profile {
+  display: flex;
+  align-items: center;
 }
 
-@media (prefers-reduced-motion: no-preference) {
-  a:nth-of-type(2) .logo {
-    animation: logo-spin infinite 20s linear;
-  }
+.avatar {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  margin-right: 0.5rem;
 }
 
-.card {
-  padding: 2em;
+.email-list {
+  max-height: calc(100vh - 100px);
+  overflow-y: auto;
+  text-align: left;
 }
 
-.read-the-docs {
-  color: #888;
+.email-item {
+  border-bottom: 1px solid #ccc;
+  padding: 0.5rem 0;
+}
+
+.subject {
+  font-weight: bold;
+}
+
+.meta {
+  font-size: 0.8rem;
+  color: #666;
+  display: flex;
+  justify-content: space-between;
 }

--- a/web-app/src/App.jsx
+++ b/web-app/src/App.jsx
@@ -1,26 +1,40 @@
-import { useState, useEffect } from 'react'
-import './App.css'
+import { useEffect, useState } from 'react';
+import './App.css';
 
 function App() {
-  const [count, setCount] = useState(0);
-  const [currentTime, setCurrentTime] = useState(0);
+  const [emails, setEmails] = useState([]);
+
   useEffect(() => {
-    fetch('/api/time').then(res => res.json()).then(data => {
-      setCurrentTime(data.time);
-    });
+    fetch('/api/emails')
+      .then((res) => res.json())
+      .then((data) => setEmails(data))
+      .catch((err) => console.error('Failed to fetch emails', err));
   }, []);
 
   return (
-    <>
-      <h1>dMail</h1>
-      <div className="card">
-        <button onClick={() => setCount((count) => count + 1)}>
-          count is {count}
-        </button>
-      </div>
-      <p>The current time is {new Date(currentTime * 1000).toLocaleString()}.</p>
-    </>
-  )
+    <div className="app">
+      <header className="header">
+        <h1>dMail</h1>
+        <div className="profile">
+          <img className="avatar" src="/vite.svg" alt="Profile" />
+          <span className="name">John Doe</span>
+        </div>
+      </header>
+      <main className="email-list">
+        {emails.map((email) => (
+          <div key={email.id} className="email-item">
+            <div className="subject">{email.subject}</div>
+            <div className="meta">
+              <span className="from">{email.from}</span>
+              <span className="timestamp">
+                {new Date(email.timestamp * 1000).toLocaleString()}
+              </span>
+            </div>
+          </div>
+        ))}
+      </main>
+    </div>
+  );
 }
 
-export default App
+export default App;

--- a/web-app/src/index.css
+++ b/web-app/src/index.css
@@ -24,8 +24,6 @@ a:hover {
 
 body {
   margin: 0;
-  display: flex;
-  place-items: center;
   min-width: 320px;
   min-height: 100vh;
 }


### PR DESCRIPTION
## Summary
- add `/api/emails` endpoint in Flask backend
- implement basic email list UI in React
- style the email list with simple layout
- tweak global body styling

## Testing
- `npm run lint`
- `python -m py_compile web-app/api/api.py`


------
https://chatgpt.com/codex/tasks/task_e_687175ad7c508320bbeeda3dbed2bdb8