### PR TITLE
Add left panel with agent prompt and email tools

### DIFF
--- a/web-app/src/App.css
+++ b/web-app/src/App.css
@@ -1,5 +1,5 @@
 .app {
-  max-width: 800px;
+  max-width: 1000px;
   margin: 0 auto;
   padding: 1rem;
   color: inherit;
@@ -28,6 +28,35 @@
   max-height: calc(100vh - 100px);
   overflow-y: auto;
   text-align: left;
+}
+
+.main-container {
+  display: flex;
+  gap: 1rem;
+}
+
+.left-panel {
+  flex: 1;
+  border-right: 1px solid #ccc;
+  padding-right: 1rem;
+}
+
+.right-panel {
+  flex: 1;
+  padding-left: 1rem;
+}
+
+.system-input {
+  width: 100%;
+  margin-bottom: 1rem;
+}
+
+.tools-list {
+  list-style: none;
+  padding: 0;
+}
+.tools-list li {
+  margin-bottom: 0.25rem;
 }
 
 .email-item {

--- a/web-app/src/App.jsx
+++ b/web-app/src/App.jsx
@@ -3,13 +3,23 @@ import './App.css';
 
 function App() {
   const [emails, setEmails] = useState([]);
+  const [systemPrompt, setSystemPrompt] = useState('');
 
   useEffect(() => {
     fetch('/api/emails')
       .then((res) => res.json())
-      .then((data) => setEmails(data))
+      .then((data) =>
+        setEmails(
+          data.map((email) => ({
+            ...email,
+            processed: false,
+          }))
+        )
+      )
       .catch((err) => console.error('Failed to fetch emails', err));
   }, []);
+
+  const unprocessedCount = emails.filter((e) => !e.processed).length;
 
   return (
     <div className="app">
@@ -20,19 +30,39 @@ function App() {
           <span className="name">John Doe</span>
         </div>
       </header>
-      <main className="email-list">
-        {emails.map((email) => (
-          <div key={email.id} className="email-item">
-            <div className="subject">{email.subject}</div>
-            <div className="meta">
-              <span className="from">{email.from}</span>
-              <span className="timestamp">
-                {new Date(email.timestamp * 1000).toLocaleString()}
-              </span>
-            </div>
+      <div className="main-container">
+        <aside className="left-panel">
+          <h2>Email Reading Agent System Prompt</h2>
+          <textarea
+            className="system-input"
+            rows={10}
+            value={systemPrompt}
+            onChange={(e) => setSystemPrompt(e.target.value)}
+          />
+          <h3>Available Tools</h3>
+          <ul className="tools-list">
+            <li>labelemail</li>
+            <li>archiveemail</li>
+            <li>draftreply</li>
+          </ul>
+        </aside>
+        <section className="right-panel">
+          <h2>Inbox ({unprocessedCount})</h2>
+          <div className="email-list">
+            {emails.map((email) => (
+              <div key={email.id} className="email-item">
+                <div className="subject">{email.subject}</div>
+                <div className="meta">
+                  <span className="from">{email.from}</span>
+                  <span className="timestamp">
+                    {new Date(email.timestamp * 1000).toLocaleString()}
+                  </span>
+                </div>
+              </div>
+            ))}
           </div>
-        ))}
-      </main>
+        </section>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add system prompt input and available tools list in left panel
- show inbox on right with count of unprocessed emails
- update styles for new two-panel layout

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68718944205483209c3f792ee24b06af