### PR TITLE
Add drafting settings modal

### DIFF
--- a/web-app/src/App.css
+++ b/web-app/src/App.css
@@ -17,6 +17,10 @@
   align-items: center;
 }
 
+.profile button {
+  margin-left: 0.5rem;
+}
+
 .avatar {
   width: 40px;
   height: 40px;

--- a/web-app/src/App.jsx
+++ b/web-app/src/App.jsx
@@ -1,9 +1,17 @@
 import { useEffect, useState } from 'react';
 import './App.css';
+import DraftingSettingsModal from './DraftingSettingsModal.jsx';
 
 function App() {
   const [emails, setEmails] = useState([]);
   const [systemPrompt, setSystemPrompt] = useState('');
+  const [showDraftModal, setShowDraftModal] = useState(false);
+  const [draftPrompts, setDraftPrompts] = useState([
+    {
+      name: 'default',
+      prompt: 'Provide concise and polite email drafts.',
+    },
+  ]);
 
   useEffect(() => {
     fetch('/api/emails')
@@ -28,6 +36,7 @@ function App() {
         <div className="profile">
           <img className="avatar" src="/vite.svg" alt="Profile" />
           <span className="name">John Doe</span>
+          <button onClick={() => setShowDraftModal(true)}>Drafting Settings</button>
         </div>
       </header>
       <div className="main-container">
@@ -63,6 +72,14 @@ function App() {
           </div>
         </section>
       </div>
+      {showDraftModal && (
+        <DraftingSettingsModal
+          isOpen={showDraftModal}
+          onClose={() => setShowDraftModal(false)}
+          prompts={draftPrompts}
+          setPrompts={setDraftPrompts}
+        />
+      )}
     </div>
   );
 }

--- a/web-app/src/DraftingSettingsModal.css
+++ b/web-app/src/DraftingSettingsModal.css
@@ -1,0 +1,51 @@
+.modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.modal {
+  background: #fff;
+  color: #000;
+  padding: 1rem;
+  border-radius: 8px;
+  width: 600px;
+  max-width: 95%;
+}
+
+.prompt-select {
+  display: flex;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.modal-content {
+  display: flex;
+  gap: 1rem;
+}
+
+.left-col,
+.right-col {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+}
+
+.left-col textarea,
+.right-col textarea {
+  width: 100%;
+  margin-bottom: 0.5rem;
+}
+
+.modal-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+}

--- a/web-app/src/DraftingSettingsModal.jsx
+++ b/web-app/src/DraftingSettingsModal.jsx
@@ -1,0 +1,98 @@
+import { useState } from 'react';
+import './DraftingSettingsModal.css';
+
+function DraftingSettingsModal({ isOpen, onClose, prompts, setPrompts }) {
+  const [selectedName, setSelectedName] = useState(prompts[0]?.name || 'default');
+  const [systemText, setSystemText] = useState(prompts[0]?.prompt || '');
+  const [newPromptName, setNewPromptName] = useState('');
+  const [testUserPrompt, setTestUserPrompt] = useState('');
+  const [testEmailDraft, setTestEmailDraft] = useState('');
+
+  if (!isOpen) return null;
+
+  const handlePromptChange = (name) => {
+    setSelectedName(name);
+    const found = prompts.find((p) => p.name === name);
+    setSystemText(found ? found.prompt : '');
+  };
+
+  const addPrompt = () => {
+    if (!newPromptName.trim()) return;
+    if (!prompts.find((p) => p.name === newPromptName)) {
+      setPrompts([...prompts, { name: newPromptName, prompt: '' }]);
+      setSelectedName(newPromptName);
+      setSystemText('');
+      setNewPromptName('');
+    }
+  };
+
+  const saveCurrentPrompt = () => {
+    setPrompts(
+      prompts.map((p) =>
+        p.name === selectedName ? { ...p, prompt: systemText } : p
+      )
+    );
+  };
+
+  const generateTest = () => {
+    saveCurrentPrompt();
+    setTestEmailDraft(
+      `Draft generated with "${selectedName}" prompt.\nUser Prompt: ${testUserPrompt}`
+    );
+  };
+
+  return (
+    <div className="modal-overlay" onClick={onClose}>
+      <div className="modal" onClick={(e) => e.stopPropagation()}>
+        <h2>Drafting Settings</h2>
+        <div className="prompt-select">
+          <label>System Prompt: </label>
+          <select
+            value={selectedName}
+            onChange={(e) => handlePromptChange(e.target.value)}
+          >
+            {prompts.map((p) => (
+              <option key={p.name} value={p.name}>
+                {p.name}
+              </option>
+            ))}
+          </select>
+          <input
+            type="text"
+            placeholder="New prompt name"
+            value={newPromptName}
+            onChange={(e) => setNewPromptName(e.target.value)}
+          />
+          <button onClick={addPrompt}>Add</button>
+        </div>
+        <div className="modal-content">
+          <div className="left-col">
+            <textarea
+              rows={10}
+              value={systemText}
+              onChange={(e) => setSystemText(e.target.value)}
+              placeholder="System prompt instructions"
+            />
+            <label>Test User Prompt</label>
+            <textarea
+              rows={4}
+              value={testUserPrompt}
+              onChange={(e) => setTestUserPrompt(e.target.value)}
+              placeholder="User prompt for test"
+            />
+          </div>
+          <div className="right-col">
+            <label>Test Email Draft</label>
+            <textarea rows={14} value={testEmailDraft} readOnly />
+          </div>
+        </div>
+        <div className="modal-actions">
+          <button onClick={generateTest}>Generate Test</button>
+          <button onClick={onClose}>Close</button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default DraftingSettingsModal;


### PR DESCRIPTION
## Summary
- create `DraftingSettingsModal` component
- show modal from App and manage stored prompts
- add button in header for opening drafting settings
- small style updates for profile and modal

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68718b79187c8320ab5c6bcbec74de21