### PR TITLE
Improve email polling strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,12 @@
 # dMail
+
+## Configuration
+
+The daemon service reads several environment variables. Two new values are
+used for controlling how far back emails are fetched and where metadata is
+stored:
+
+- `LOOKBACK_DAYS` &ndash; number of days to fetch emails on startup if no
+  previous timestamp has been recorded. Defaults to `5`.
+- `DYNAMODB_META_TABLE` &ndash; DynamoDB table that stores the last processed
+  timestamp for each IMAP user. Defaults to `dmail_metadata`.

--- a/daemon-service/config_reader.py
+++ b/daemon-service/config_reader.py
@@ -11,3 +11,11 @@ PASSWORD = os.getenv('PASSWORD') or secrets.PASSWORD
 # AWS configuration for DynamoDB
 AWS_REGION = os.getenv('AWS_REGION', 'us-east-1')
 DYNAMODB_TABLE = os.getenv('DYNAMODB_TABLE', 'dmail_emails')
+
+# Table used for storing metadata such as the last processed
+# email timestamp for the IMAP user.
+DYNAMODB_META_TABLE = os.getenv('DYNAMODB_META_TABLE', 'dmail_metadata')
+
+# Number of days to look back when fetching emails on startup
+# if no previous timestamp is stored.
+LOOKBACK_DAYS = int(os.getenv('LOOKBACK_DAYS', '5'))


### PR DESCRIPTION
## Summary
- add `DYNAMODB_META_TABLE` and `LOOKBACK_DAYS` configuration variables
- record the last processed email timestamp in DynamoDB
- fetch emails using the last seen timestamp instead of UNSEEN search
- document new configuration options

## Testing
- `python -m py_compile daemon-service/*.py`

------
https://chatgpt.com/codex/tasks/task_e_6872b56f4ee083208b68a600cb25ae0e