### PR TITLE
Implement onboarding with Gmail app password

### DIFF
--- a/web-app/api/api.py
+++ b/web-app/api/api.py
@@ -1,14 +1,120 @@
 import time
 import json
-from flask import Flask, jsonify
-import boto3
 import os
+import asyncio
+import imaplib
+import threading
+import importlib.util
+from datetime import datetime, timedelta
+
+import boto3
+from flask import Flask, jsonify, request
+
+BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+observer_path = os.path.join(BASE_DIR, 'daemon-service', 'observer.py')
+spec = importlib.util.spec_from_file_location('observer', observer_path)
+observer = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(observer)
+
 
 AWS_REGION = os.getenv('AWS_REGION', 'us-east-1')
 DYNAMODB_TABLE = os.getenv('DYNAMODB_TABLE', 'dmail_emails')
+HOST = os.getenv('HOST', 'imap.gmail.com')
+DYNAMODB_META_TABLE = os.getenv('DYNAMODB_META_TABLE', 'dmail_metadata')
+DYNAMODB_USERS_TABLE = os.getenv('DYNAMODB_USERS_TABLE', 'dmail_users')
+LOOKBACK_DAYS = int(os.getenv('LOOKBACK_DAYS', '5'))
 
 dynamodb = boto3.resource('dynamodb', region_name=AWS_REGION)
 email_table = dynamodb.Table(DYNAMODB_TABLE)
+meta_table = dynamodb.Table(DYNAMODB_META_TABLE)
+users_table = dynamodb.Table(DYNAMODB_USERS_TABLE)
+
+# Track running observer threads to avoid duplicates
+observer_threads = {}
+
+
+def start_observer(host, user, password):
+    """Start background monitoring for a user's inbox."""
+    if user in observer_threads:
+        return
+
+    def run():
+        asyncio.run(observer.loop_and_retry(host, user, password))
+
+    thread = threading.Thread(target=run, daemon=True)
+    thread.start()
+    observer_threads[user] = thread
+
+
+def get_last_processed_date(user):
+    try:
+        response = meta_table.get_item(Key={"user": user})
+        item = response.get("Item")
+        if item and item.get("last_processed"):
+            return datetime.fromisoformat(item["last_processed"])
+    except Exception as e:
+        print(f"Error getting last processed date: {e}")
+    return None
+
+
+def update_last_processed_date(user, dt):
+    if not dt:
+        return
+    try:
+        current = get_last_processed_date(user)
+        if not current or dt > current:
+            meta_table.put_item(Item={"user": user, "last_processed": dt.isoformat()})
+    except Exception as e:
+        print(f"Error updating last processed date: {e}")
+
+
+def process_email(current_user, parsed_email):
+    from_email = parsed_email.from_
+    if len(parsed_email.reply_to) > 0:
+        from_email = parsed_email.reply_to
+
+    body = parsed_email.text_plain[0] if parsed_email.text_plain else ""
+
+    try:
+        email_table.put_item(
+            Item={
+                "message_id": parsed_email.message_id or "",
+                "subject": parsed_email.subject or "",
+                "to": json.dumps(parsed_email.to),
+                "from": json.dumps(from_email),
+                "body": body,
+                "date": parsed_email.date.isoformat() if parsed_email.date else "",
+            }
+        )
+        if parsed_email.date:
+            update_last_processed_date(current_user, parsed_email.date)
+    except Exception as e:
+        print(f"Error saving email: {e}")
+
+
+def hydrate_inbox(host, user, password):
+    """Fetch recent emails and store them."""
+    try:
+        imap = imaplib.IMAP4_SSL(host)
+        imap.login(user, password)
+        imap.select("INBOX")
+        last_processed = get_last_processed_date(user)
+        if last_processed:
+            since_dt = last_processed
+        else:
+            since_dt = datetime.utcnow() - timedelta(days=LOOKBACK_DAYS)
+        since_str = since_dt.strftime("%d-%b-%Y")
+        typ, data = imap.search(None, f"(SINCE {since_str})")
+        ids = data[0].split()
+        for msg_id in ids:
+            typ, msg_data = imap.fetch(msg_id, "(RFC822)")
+            for part in msg_data:
+                if isinstance(part, tuple):
+                    parsed = observer.mailparser.parse_from_bytes(part[1])
+                    process_email(user, parsed)
+        imap.logout()
+    except Exception as e:
+        print(f"Error during hydration for {user}: {e}")
 
 app = Flask(__name__)
 
@@ -37,4 +143,31 @@ def get_emails():
         return jsonify(emails)
     except Exception as e:
         return jsonify({'error': str(e)}), 500
+
+
+@app.route('/api/onboard', methods=['POST'])
+def onboard():
+    data = request.get_json() or {}
+    email = data.get('email')
+    password = data.get('password')
+    if not email or not password:
+        return jsonify({'error': 'email and password required'}), 400
+
+    # verify credentials with Gmail
+    try:
+        imap = imaplib.IMAP4_SSL(HOST)
+        imap.login(email, password)
+        imap.logout()
+    except Exception:
+        return jsonify({'error': 'Invalid IMAP credentials'}), 401
+
+    try:
+        users_table.put_item(Item={'user': email, 'host': HOST, 'password': password})
+    except Exception as e:
+        return jsonify({'error': str(e)}), 500
+
+    hydrate_inbox(HOST, email, password)
+    start_observer(HOST, email, password)
+
+    return jsonify({'status': 'success'})
 

--- a/web-app/src/App.css
+++ b/web-app/src/App.css
@@ -78,3 +78,20 @@
   display: flex;
   justify-content: space-between;
 }
+
+.onboarding {
+  display: flex;
+  flex-direction: column;
+  max-width: 300px;
+  margin: 2rem auto;
+  gap: 0.5rem;
+}
+.onboarding input {
+  padding: 0.5rem;
+}
+.onboarding button {
+  padding: 0.5rem;
+}
+.error {
+  color: red;
+}

--- a/web-app/src/App.jsx
+++ b/web-app/src/App.jsx
@@ -1,8 +1,12 @@
 import { useEffect, useState } from 'react';
 import './App.css';
 import DraftingSettingsModal from './DraftingSettingsModal.jsx';
+import Onboarding from './Onboarding.jsx';
 
 function App() {
+  const [currentUser, setCurrentUser] = useState(
+    localStorage.getItem('userEmail') || ''
+  );
   const [emails, setEmails] = useState([]);
   const [systemPrompt, setSystemPrompt] = useState('');
   const [showDraftModal, setShowDraftModal] = useState(false);
@@ -14,6 +18,7 @@ function App() {
   ]);
 
   useEffect(() => {
+    if (!currentUser) return;
     fetch('/api/emails')
       .then((res) => res.json())
       .then((data) =>
@@ -25,9 +30,17 @@ function App() {
         )
       )
       .catch((err) => console.error('Failed to fetch emails', err));
-  }, []);
+  }, [currentUser]);
 
   const unprocessedCount = emails.filter((e) => !e.processed).length;
+
+  if (!currentUser) {
+    return (
+      <div className="app">
+        <Onboarding onComplete={setCurrentUser} />
+      </div>
+    );
+  }
 
   return (
     <div className="app">

--- a/web-app/src/Onboarding.jsx
+++ b/web-app/src/Onboarding.jsx
@@ -1,0 +1,51 @@
+import { useState } from 'react';
+import './App.css';
+
+export default function Onboarding({ onComplete }) {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setError('');
+    try {
+      const res = await fetch('/api/onboard', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email, password }),
+      });
+      if (!res.ok) {
+        const data = await res.json();
+        setError(data.error || 'Failed to onboard');
+        return;
+      }
+      localStorage.setItem('userEmail', email);
+      onComplete(email);
+    } catch {
+      setError('Failed to connect to server');
+    }
+  };
+
+  return (
+    <form className="onboarding" onSubmit={handleSubmit}>
+      <h2>Connect Gmail</h2>
+      <input
+        type="email"
+        placeholder="Email"
+        value={email}
+        onChange={(e) => setEmail(e.target.value)}
+        required
+      />
+      <input
+        type="password"
+        placeholder="Gmail App Password"
+        value={password}
+        onChange={(e) => setPassword(e.target.value)}
+        required
+      />
+      <button type="submit">Submit</button>
+      {error && <div className="error">{error}</div>}
+    </form>
+  );
+}


### PR DESCRIPTION
## Summary
- add Gmail onboarding endpoint to Flask API
- start background observer on successful onboarding
- hydrate inbox for recent messages
- add React onboarding component
- update main app to show onboarding flow and styles

## Testing
- `npm run lint`
- `python -m py_compile web-app/api/api.py`


------
https://chatgpt.com/codex/tasks/task_e_6872bf7660408320b687c93621cdb526