### PR TITLE
Add AI email triage

### DIFF
--- a/daemon-service/ai_processor.py
+++ b/daemon-service/ai_processor.py
@@ -1,0 +1,132 @@
+import asyncio
+import json
+import os
+from typing import Optional
+
+import openai
+from google.oauth2.credentials import Credentials
+from googleapiclient.discovery import build
+import boto3
+from config_reader import AWS_REGION, DYNAMODB_META_TABLE
+
+SCOPES = ['https://www.googleapis.com/auth/gmail.modify']
+TOKEN_DIR = os.getenv('GMAIL_TOKEN_DIR', os.path.join(os.path.dirname(__file__), 'gmail_tokens'))
+OPENAI_API_KEY = os.getenv('OPENAI_API_KEY')
+DEFAULT_PROMPT = (
+    "You are an email triage agent. Decide if a Gmail label should be applied. "
+    "Respond with JSON like {'label': \"LabelName\"} or {'label': null}."
+)
+
+dynamodb = boto3.resource('dynamodb', region_name=AWS_REGION)
+openai.api_key = OPENAI_API_KEY
+meta_table = dynamodb.Table(DYNAMODB_META_TABLE)
+
+
+def get_prompt() -> str:
+    """Fetch the latest prompt from DynamoDB or use default."""
+    try:
+        resp = meta_table.get_item(Key={"user": "reading_prompt"})
+        item = resp.get("Item")
+        if item and item.get("prompt"):
+            return item["prompt"]
+    except Exception as e:
+        print(f"Error fetching prompt: {e}")
+    return DEFAULT_PROMPT
+
+
+def get_gmail_service(user: str):
+    token_path = os.path.join(TOKEN_DIR, f"{user}.json")
+    if not os.path.exists(token_path):
+        print(f"Gmail token not found for {user}: {token_path}")
+        return None
+    creds = Credentials.from_authorized_user_file(token_path, SCOPES)
+    return build("gmail", "v1", credentials=creds)
+
+
+def ensure_label(service, name: str) -> Optional[str]:
+    try:
+        labels_resp = service.users().labels().list(userId="me").execute()
+        for lbl in labels_resp.get("labels", []):
+            if lbl.get("name", "").lower() == name.lower():
+                return lbl["id"]
+        new_label = (
+            service.users()
+            .labels()
+            .create(userId="me", body={"name": name})
+            .execute()
+        )
+        return new_label.get("id")
+    except Exception as e:
+        print(f"Error ensuring label {name}: {e}")
+        return None
+
+
+def find_message(service, rfc822_msgid: str) -> Optional[str]:
+    try:
+        resp = (
+            service.users()
+            .messages()
+            .list(userId="me", q=f"rfc822msgid:{rfc822_msgid}")
+            .execute()
+        )
+        msgs = resp.get("messages", [])
+        if not msgs:
+            return None
+        return msgs[0]["id"]
+    except Exception as e:
+        print(f"Error locating message {rfc822_msgid}: {e}")
+        return None
+
+
+async def handle_email(user: str, parsed_email) -> None:
+    if not OPENAI_API_KEY:
+        print("OPENAI_API_KEY not set, skipping AI processing")
+        return
+
+    body = parsed_email.text_plain[0] if parsed_email.text_plain else ""
+    content = f"Subject: {parsed_email.subject}\nFrom: {parsed_email.from_}\n\n{body}"
+
+    def run_openai():
+        return openai.ChatCompletion.create(
+            model="gpt-3.5-turbo",
+            messages=[
+                {"role": "system", "content": get_prompt()},
+                {"role": "user", "content": content},
+            ],
+            temperature=0,
+        )
+
+    try:
+        resp = await asyncio.to_thread(run_openai)
+    except Exception as e:
+        print(f"OpenAI request failed: {e}")
+        return
+
+    text = resp.choices[0].message.content.strip()
+    try:
+        data = json.loads(text)
+    except Exception:
+        print(f"Unable to parse LLM response: {text}")
+        return
+
+    label_name = data.get("label")
+    if not label_name:
+        return
+
+    service = get_gmail_service(user)
+    if not service:
+        return
+    msg_id = find_message(service, parsed_email.message_id)
+    if not msg_id:
+        print("Could not find Gmail message to label")
+        return
+    label_id = ensure_label(service, label_name)
+    if not label_id:
+        return
+    try:
+        service.users().messages().modify(
+            userId="me", id=msg_id, body={"addLabelIds": [label_id]}
+        ).execute()
+        print(f"Applied label '{label_name}' to message {parsed_email.message_id}")
+    except Exception as e:
+        print(f"Failed to label message: {e}")

--- a/daemon-service/observer.py
+++ b/daemon-service/observer.py
@@ -3,6 +3,7 @@ from asyncio import wait_for
 import mailparser
 import aiohttp
 import aioimaplib
+import ai_processor
 from config_reader import (
     HOST,
     USER,
@@ -180,6 +181,7 @@ async def imap_loop(host, user, password) -> None:
                         parsed_email.message_id,
                         parsed_email.date
                     )
+                    asyncio.create_task(ai_processor.handle_email(user, parsed_email))
                     print(f"Total processed messages tracked: {len(processed_message_ids)}")
                 except Exception as e:
                     print(f'Error processing individual email: {str(e)}')

--- a/daemon-service/requirements.txt
+++ b/daemon-service/requirements.txt
@@ -12,3 +12,7 @@ simplejson==3.19.2
 six==1.16.0
 yarl==1.9.4
 boto3==1.34.21
+openai==1.3.7
+google-api-python-client==2.112.0
+google-auth==2.25.2
+google-auth-oauthlib==1.1.0

--- a/web-app/api/api.py
+++ b/web-app/api/api.py
@@ -171,3 +171,25 @@ def onboard():
 
     return jsonify({'status': 'success'})
 
+
+@app.route('/api/prompt', methods=['GET', 'POST'])
+def reading_prompt():
+    """Get or update the system prompt for the reading agent."""
+    if request.method == 'POST':
+        data = request.get_json() or {}
+        prompt = data.get('prompt')
+        if not prompt:
+            return jsonify({'error': 'prompt required'}), 400
+        try:
+            meta_table.put_item(Item={'user': 'reading_prompt', 'prompt': prompt})
+        except Exception as e:
+            return jsonify({'error': str(e)}), 500
+        return jsonify({'status': 'saved'})
+    else:
+        try:
+            resp = meta_table.get_item(Key={'user': 'reading_prompt'})
+            prompt = resp.get('Item', {}).get('prompt', '')
+            return jsonify({'prompt': prompt})
+        except Exception as e:
+            return jsonify({'error': str(e)}), 500
+


### PR DESCRIPTION
## Summary
- integrate OpenAI with Gmail for acting on new emails
- add ai_processor module with Gmail label tool
- invoke ai processing in IMAP observer
- expose `/api/prompt` endpoint for managing the reading prompt
- update daemon-service requirements for OpenAI and Gmail APIs

## Testing
- `python3 -m pip install -r daemon-service/requirements.txt`
- `python3 -m py_compile daemon-service/*.py web-app/api/*.py`

------
https://chatgpt.com/codex/tasks/task_e_6872c2904ffc8320aeb3a1886e7098ac