### PR TITLE
Add draft email workflow

### DIFF
--- a/daemon-service/observer.py
+++ b/daemon-service/observer.py
@@ -102,7 +102,9 @@ def processUnread(current_user, to, user_info, body, subject, message_id, date=N
                 'body': all_body,
                 'date': date.isoformat() if date else '',
                 'processed': False,
-                'action': ''
+                'action': '',
+                'draft': '',
+                'account': current_user,
             }
         )
         if date:

--- a/web-app/src/DraftingSettingsModal.jsx
+++ b/web-app/src/DraftingSettingsModal.jsx
@@ -32,6 +32,11 @@ function DraftingSettingsModal({ isOpen, onClose, prompts, setPrompts }) {
         p.name === selectedName ? { ...p, prompt: systemText } : p
       )
     );
+    fetch('/api/draft_prompt', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ prompt: systemText }),
+    });
   };
 
   const generateTest = () => {

--- a/web-app/src/EmailDraftModal.jsx
+++ b/web-app/src/EmailDraftModal.jsx
@@ -1,0 +1,36 @@
+import { useState, useEffect } from 'react';
+import './DraftingSettingsModal.css';
+
+export default function EmailDraftModal({ isOpen, onClose, email, onSend }) {
+  const [text, setText] = useState('');
+
+  useEffect(() => {
+    if (email) {
+      setText(email.draft || '');
+    }
+  }, [email]);
+
+  if (!isOpen || !email) return null;
+
+  const handleSend = () => {
+    onSend(text);
+  };
+
+  return (
+    <div className="modal-overlay" onClick={onClose}>
+      <div className="modal" onClick={(e) => e.stopPropagation()}>
+        <h2>Email Draft</h2>
+        <div className="subject">{email.subject}</div>
+        <textarea
+          rows={10}
+          value={text}
+          onChange={(e) => setText(e.target.value)}
+        />
+        <div className="modal-actions">
+          <button onClick={handleSend}>Send</button>
+          <button onClick={onClose}>Close</button>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- let AI draft emails using new `draftemail` tool
- track drafts per email and expose through API
- manage drafting prompt
- allow users to edit and send generated drafts
- show emails awaiting a human in the UI

## Testing
- `npm run lint`
- `python -m py_compile daemon-service/*.py web-app/api/api.py`

------
https://chatgpt.com/codex/tasks/task_e_687302537588832094c56cccb1a9de13