### PR TITLE
Implement archive email tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,12 @@ Whitelisting rules for deciding which emails are stored can be managed via the
 `/api/whitelist` endpoint. Rules are saved in the metadata table under the
 `whitelist_rules` key and may match sender addresses, subject text, or rely on
 an LLM classification.
+
+## LLM Actions
+
+When processing emails, the system's language model can perform several actions
+by returning JSON instructions:
+
+- `{"label": "LabelName"}` &ndash; apply the given Gmail label.
+- `{"draft": "Reply text"}` &ndash; store a draft reply for human review.
+- `{"archive": true}` &ndash; archive the email by removing it from the Inbox.


### PR DESCRIPTION
## Summary
- enable LLM to archive emails through Gmail API
- document JSON actions for LLM

## Testing
- `python -m py_compile daemon-service/*.py web-app/api/api.py`

------
https://chatgpt.com/codex/tasks/task_e_687312b777048320bd06dff6379ca43a