### PR TITLE
Update email draft modals with sidepanel layout

### DIFF
--- a/web-app/src/AwaitingHumanModal.jsx
+++ b/web-app/src/AwaitingHumanModal.jsx
@@ -110,7 +110,10 @@ export default function AwaitingHumanModal({ isOpen, onClose, email, onSend, onD
 
   return (
     <div className="modal-overlay" onClick={onClose}>
-      <div className="modal awaiting-human-modal" onClick={(e) => e.stopPropagation()}>
+      <div
+        className="modal sidepanel awaiting-human-modal"
+        onClick={(e) => e.stopPropagation()}
+      >
         <div className="modal-header">
           <h2>Email Draft Review</h2>
           <div className="email-info">

--- a/web-app/src/DraftingSettingsModal.css
+++ b/web-app/src/DraftingSettingsModal.css
@@ -29,6 +29,36 @@
   overflow: hidden; /* Hide overflow from the main modal container */
 }
 
+/* Sidepanel variant for modals that slide in from the right */
+.modal.sidepanel {
+  position: fixed;
+  top: 0;
+  right: 0;
+  height: 100vh;
+  max-height: none;
+  width: 480px;
+  border-radius: 0;
+  border-left: 1px solid #30363d;
+  border-top-left-radius: 16px;
+  border-bottom-left-radius: 16px;
+  animation: slideIn 0.2s ease-out;
+}
+
+@keyframes slideIn {
+  from {
+    transform: translateX(100%);
+  }
+  to {
+    transform: translateX(0);
+  }
+}
+
+@media (max-width: 768px) {
+  .modal.sidepanel {
+    width: 100vw;
+  }
+}
+
 .modal-header {
   padding: 1rem 1.5rem;
   border-bottom: 1px solid #30363d;

--- a/web-app/src/EmailDraftModal.jsx
+++ b/web-app/src/EmailDraftModal.jsx
@@ -18,14 +18,36 @@ export default function EmailDraftModal({ isOpen, onClose, email, onSend }) {
 
   return (
     <div className="modal-overlay" onClick={onClose}>
-      <div className="modal" onClick={(e) => e.stopPropagation()}>
-        <h2>Email Draft</h2>
-        <div className="subject">{email.subject}</div>
-        <textarea
-          rows={10}
-          value={text}
-          onChange={(e) => setText(e.target.value)}
-        />
+      <div
+        className="modal sidepanel email-draft-modal"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="modal-header">
+          <h2>Email Draft</h2>
+          <div className="email-info">
+            <div className="subject">Subject: {email.subject}</div>
+            <div className="from">From: {email.from}</div>
+          </div>
+        </div>
+
+        <div className="modal-content">
+          <div className="left-col">
+            <div className="email-display-section">
+              <label>Original Email</label>
+              <textarea value={email.body || ''} readOnly className="readonly" />
+            </div>
+            <div className="draft-compose-section">
+              <label>Your Response</label>
+              <textarea
+                value={text}
+                onChange={(e) => setText(e.target.value)}
+                placeholder="Write your response..."
+              />
+            </div>
+          </div>
+          <div className="right-col" />
+        </div>
+
         <div className="modal-actions">
           <button onClick={handleSend}>Send</button>
           <button onClick={onClose}>Close</button>

--- a/web-app/src/ProcessedEmailModal.jsx
+++ b/web-app/src/ProcessedEmailModal.jsx
@@ -88,7 +88,10 @@ export default function ProcessedEmailModal({ isOpen, onClose, email, onSend }) 
 
   return (
     <div className="modal-overlay" onClick={onClose}>
-      <div className="modal processed-email-modal" onClick={(e) => e.stopPropagation()}>
+      <div
+        className="modal sidepanel processed-email-modal"
+        onClick={(e) => e.stopPropagation()}
+      >
         <div className="modal-header">
           <h2>{isSentEmail ? 'Sent Email' : 'Draft Email'}</h2>
           <div className="email-info">


### PR DESCRIPTION
## Summary
- add sidepanel styles to shared modal CSS
- restyle EmailDraftModal with new layout
- apply sidepanel layout to AwaitingHumanModal and ProcessedEmailModal

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68792d966cc08327acb6157d64c74d93